### PR TITLE
✨ feat(auth): create Parent TypeORM entity with auth fields

### DIFF
--- a/src/modules/auth/domain/entities/parent.entity.ts
+++ b/src/modules/auth/domain/entities/parent.entity.ts
@@ -1,0 +1,67 @@
+import {
+  Entity,
+  Column,
+  PrimaryColumn,
+  BeforeInsert,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { uuidv7 } from 'uuidv7';
+
+export enum AuthProvider {
+  EMAIL = 'EMAIL',
+  GOOGLE = 'GOOGLE',
+  APPLE = 'APPLE',
+}
+
+@Entity()
+export class Parent {
+  @PrimaryColumn()
+  id: string;
+
+  @Column()
+  username: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column({ nullable: true })
+  password_hash: string | null;
+
+  @Column()
+  pin_hash: string;
+
+  @Column({ nullable: true })
+  phone_number: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: AuthProvider,
+  })
+  auth_provider: AuthProvider;
+
+  @Column({ nullable: true })
+  external_subject_id: string | null;
+
+  @Column({ default: false })
+  lock_alerts: boolean;
+
+  @Column({ default: false })
+  limit_warning: boolean;
+
+  @Column({ default: true })
+  is_active: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @BeforeInsert()
+  generateId() {
+    if (!this.id) {
+      this.id = uuidv7();
+    }
+  }
+}


### PR DESCRIPTION
## Linked Issue
Closes #17

## GitHub Project
- [x] Added this PR to the project board
- [x] Issue is in the same project board

## Description 📑
Creates the `Parent` TypeORM entity in the auth domain with all required
authentication fields, UUIDv7 primary key generation, and the AuthProvider enum.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes
- Added `Parent` entity at `auth/domain/entities/parent.entity.ts`
- Added `AuthProvider` enum (EMAIL | GOOGLE | APPLE)
- Applied all required TypeORM decorators
- `@BeforeInsert()` assigns UUIDv7 if no id is present
- `password_hash` is nullable for OAuth parents

## How to test 🚦
- Confirm all columns match the acceptance criteria

