### PR TITLE
Feature/#3 create admin entity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-PORT=3000
-DATABASE_URL=
-JWT_SECRET=
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=khaliltouils
+DB_NAME=elFulk

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,12 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
         "dotenv": "^17.3.1",
+        "joi": "^18.0.2",
         "pg": "^8.18.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.28",
+        "uuid": "^13.0.0",
         "uuidv7": "^1.1.0"
       },
       "devDependencies": {
@@ -33,6 +35,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -945,6 +948,54 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2652,6 +2703,12 @@
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -2975,6 +3032,13 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.15.10",
@@ -7372,6 +7436,24 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10566,6 +10648,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/typeorm/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -10751,16 +10846,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/uuidv7": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
     "dotenv": "^17.3.1",
+    "joi": "^18.0.2",
     "pg": "^8.18.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.28",
+    "uuid": "^13.0.0",
     "uuidv7": "^1.1.0"
   },
   "devDependencies": {
@@ -45,6 +47,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/modules/auth/domain/entities/admin-role-assignment.entity.ts
+++ b/src/modules/auth/domain/entities/admin-role-assignment.entity.ts
@@ -4,15 +4,28 @@ import {
   ManyToOne,
   JoinColumn,
   CreateDateColumn,
+  Column,
 } from 'typeorm';
 import { Admin } from './admin.entity';
 import { AdminRole } from './admin-role.entity';
 
 @Entity()
-export class AdminRoleAssignment{
-@PrimaryGeneratedColumn()
-id:number
-    
-}
+export class AdminRoleAssignment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
+  @ManyToOne(() => Admin, (admin) => admin.roleAssignments, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'admin_id' })
+  admin: Admin;
+
+  @ManyToOne(() => AdminRole, (role) => role.assignments, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'role_id' })
+  role: AdminRole;
+
+  @CreateDateColumn({ name: 'assigned_at' })
+  assignedAt: Date;
+
+  @Column({ name: 'assigned_by' })
+  assignedBy: string; 
+}
 

--- a/src/modules/auth/domain/entities/admin-role-assignment.entity.ts
+++ b/src/modules/auth/domain/entities/admin-role-assignment.entity.ts
@@ -1,0 +1,18 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { Admin } from './admin.entity';
+import { AdminRole } from './admin-role.entity';
+
+@Entity()
+export class AdminRoleAssignment{
+@PrimaryGeneratedColumn()
+id:number
+    
+}
+
+

--- a/src/modules/auth/domain/entities/admin-role.entity.ts
+++ b/src/modules/auth/domain/entities/admin-role.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { AdminRoleAssignment } from './admin-role-assignment.entity';
 
 @Entity()
 export class AdminRole{
@@ -11,6 +12,7 @@ name:string;
 @Column('text',{array:true})
 permissions: string[];
 
-
+  @OneToMany(() => AdminRoleAssignment, (assignment) => assignment.role)
+  assignments: AdminRoleAssignment[];
 
 }

--- a/src/modules/auth/domain/entities/admin-role.entity.ts
+++ b/src/modules/auth/domain/entities/admin-role.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+
+@Entity()
+export class AdminRole{
+@PrimaryGeneratedColumn()
+id:number;
+
+@Column({unique:true})
+name:string;
+
+@Column('text',{array:true})
+permissions: string[];
+
+
+
+}

--- a/src/modules/auth/domain/entities/admin.entity.ts
+++ b/src/modules/auth/domain/entities/admin.entity.ts
@@ -5,8 +5,11 @@ import {
   BeforeInsert,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany
 } from 'typeorm';
 import { uuidv7 } from 'uuidv7';
+import { AdminRoleAssignment } from './admin-role-assignment.entity';
+
 
 @Entity()
 export class Admin {
@@ -34,4 +37,7 @@ export class Admin {
 
   @UpdateDateColumn()
   updated_at: Date;
+
+@OneToMany(() => AdminRoleAssignment, (assignment) => assignment.admin)
+  roleAssignments: AdminRoleAssignment[];
 }

--- a/src/modules/auth/domain/entities/admin.entity.ts
+++ b/src/modules/auth/domain/entities/admin.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  Column,
+  PrimaryColumn,
+  BeforeInsert,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { uuidv7 } from 'uuidv7';
+
+@Entity()
+export class Admin {
+
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column()
+  username: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column({ nullable: true })
+  password_hash: string | null;
+
+  @Column({ nullable: true })
+  author: string | null;
+
+  @Column({ default: true })
+  is_active: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}


### PR DESCRIPTION
## Linked Issue
Closes #3

## GitHub Project
- [x] Added this PR to the project board
- [x] Issue is in the same project board

## Description 📑
This PR initializes the core Admin authentication data structure. It implements a Many-to-Many relationship between Admins and Roles using a dedicated Assignment entity. All primary keys are generated using **UUIDv7** for time-ordered database performance.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 🏗️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Changes
This pull request includes the following changes:
* Created the **Admin entity** with `uuidv7` primary key and `BeforeInsert` hook.
* Created **AdminRole entity** to define system permissions (SuperAdmin, Editor, etc.).
* Created **AdminRoleAssignment** as a join-entity to link Admins and Roles.
* Implemented `onDelete: 'CASCADE'` on relationships to ensure data integrity.



## How to test 🚦
1. Run `npm install` to ensure all new dependencies (`uuidv7`, `typeorm`, etc.) are installed.
2. Start the application using `npm run start:dev`.
3. Verify the database logs show the creation of `admin`, `admin_role`, and `admin_role_assignment` tables.
4. Check your Postgres client (e.g., pgAdmin) to confirm the `id` columns are of type `uuid`.



