### PR TITLE
✨ feat(access-policy): add AccessPolicy entity

### DIFF
--- a/src/modules/auth/domain/entities/access-policy.entity.ts
+++ b/src/modules/auth/domain/entities/access-policy.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  Column,
+  PrimaryColumn,
+  BeforeInsert,
+  CreateDateColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { uuidv7 } from 'uuidv7';
+
+@Entity()
+export class AccessPolicy {
+  @PrimaryColumn()
+  id: string;
+
+  @Column({ unique: true })
+  child_id: string;
+
+  @Column({ type: 'int', nullable: true })
+  daily_limit_minutes: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  weekly_limit_minutes: number | null;
+
+  @Column({ type: 'time', nullable: true })
+  allowed_start_time: string | null;
+
+  @Column({ type: 'time', nullable: true })
+  allowed_end_time: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  max_age_rating: number | null;
+
+  @Column({ default: false })
+  lock_enabled: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @BeforeInsert()
+  generateId() {
+    if (!this.id) {
+      this.id = uuidv7();
+    }
+  }
+}


### PR DESCRIPTION
## Linked Issue

Closes #<11>

## GitHub Project
- [x] Added this PR to the project board
- [x] Issue is in the same project board

## Description 📑
Adds the `AccessPolicy` entity in the entities domain.
One policy per child is enforced via `unique: true` on `child_id`.
Fields match the diagram exactly.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes
- Added `AccessPolicy` TypeORM entity with all fields from diagram
- `child_id` is unique (1 policy per child enforced at DB level)

## How to test 🚦
1. Run app with `synchronize: true` — verify `access_policy` table is created
2. Try inserting two policies for the same `child_id` — should throw unique constraint error
