### PR TITLE
feat(admin): add idempotent admin seed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node build/main",
+    "seed:admin": "ts-node src/seeds/admin.seed.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/README.md
+++ b/src/README.md
@@ -55,6 +55,26 @@ npm run start:dev
 docker compose -f docker/docker-compose.yml up --build
 ```
 
+## Admin Seed (Sample Admin Accounts)
+
+To quickly test the current admin workflow without manual database inserts, run:
+
+```bash
+npm run seed:admin
+```
+
+The seed is idempotent — running it multiple times will not create duplicate accounts.
+
+**Password for all seeded accounts:** `Password123!`
+
+| Email                            | Role        | Status                           |
+| -------------------------------- | ----------- | -------------------------------- |
+| `superadmin@seed.local`          | SUPER_ADMIN | ACTIVE                           |
+| `moderator.active@seed.local`    | MODERATOR   | ACTIVE (approved by SUPER_ADMIN) |
+| `moderator.pending@seed.local`   | MODERATOR   | PENDING                          |
+| `moderator.rejected@seed.local`  | MODERATOR   | REJECTED                         |
+| `moderator.suspended@seed.local` | MODERATOR   | SUSPENDED                        |
+
 ## Team Tasks (Next Steps)
 
 1. Decide inheritance strategy for `User` -> `Parent/Child/Admin`.

--- a/src/seeds/admin.seed.ts
+++ b/src/seeds/admin.seed.ts
@@ -1,0 +1,169 @@
+import 'dotenv/config';
+import { Repository } from 'typeorm';
+import { auth } from '../auth';
+import { dataSource } from '../typeorm/data-source';
+import { AccountStatus, Admin, AdminRole } from '../modules/admin/admin.entity';
+// The shared data source only loads entities from the root "typeorm/entities"
+// folder (Better Auth tables). Register the Admin entity manually so its
+// repository is available in this seed script.
+type EntityClass = new (...args: never[]) => unknown;
+(dataSource.options.entities as Array<string | EntityClass>).push(Admin);
+const SEED_PASSWORD = 'Password123!';
+
+interface SeedAccount {
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: AdminRole;
+  status: AccountStatus;
+  approved: boolean;
+}
+
+const SEED_ACCOUNTS: SeedAccount[] = [
+  {
+    email: 'superadmin@seed.local',
+    firstName: 'Super',
+    lastName: 'Admin',
+    role: AdminRole.SUPER_ADMIN,
+    status: AccountStatus.ACTIVE,
+    approved: false,
+  },
+  {
+    email: 'moderator.active@seed.local',
+    firstName: 'Active',
+    lastName: 'Moderator',
+    role: AdminRole.MODERATOR,
+    status: AccountStatus.ACTIVE,
+    approved: true,
+  },
+  {
+    email: 'moderator.pending@seed.local',
+    firstName: 'Pending',
+    lastName: 'Moderator',
+    role: AdminRole.MODERATOR,
+    status: AccountStatus.PENDING,
+    approved: false,
+  },
+  {
+    email: 'moderator.rejected@seed.local',
+    firstName: 'Rejected',
+    lastName: 'Moderator',
+    role: AdminRole.MODERATOR,
+    status: AccountStatus.REJECTED,
+    approved: false,
+  },
+  {
+    email: 'moderator.suspended@seed.local',
+    firstName: 'Suspended',
+    lastName: 'Moderator',
+    role: AdminRole.MODERATOR,
+    status: AccountStatus.SUSPENDED,
+    approved: false,
+  },
+];
+
+async function getAdminByEmail(
+  adminRepo: Repository<Admin>,
+  email: string,
+): Promise<Admin | null> {
+  const admins = await adminRepo.find({ relations: ['user', 'approvedBy'] });
+  return (
+    admins.find(
+      (admin) => admin.user?.email?.toLowerCase() === email.toLowerCase(),
+    ) ?? null
+  );
+}
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const adminRepo = dataSource.getRepository(Admin);
+  const seededAdmins = new Map<string, Admin>();
+
+  for (const account of SEED_ACCOUNTS) {
+    let admin = await getAdminByEmail(adminRepo, account.email);
+
+    if (admin) {
+      // Idempotency: account already exists, only fix drifted data.
+      let dirty = false;
+      if (admin.role !== account.role) {
+        admin.role = account.role;
+        dirty = true;
+      }
+      if (admin.status !== account.status) {
+        admin.status = account.status;
+        dirty = true;
+      }
+      if (dirty) {
+        admin = await adminRepo.save(admin);
+        console.log(`[UPDATED] ${account.email}`);
+      } else {
+        console.log(`[SKIPPED] ${account.email} (already exists)`);
+      }
+    } else {
+      try {
+        // 1) Create the Better Auth user (email + password).
+        const result = (await auth.api.signUpEmail({
+          body: {
+            email: account.email,
+            password: SEED_PASSWORD,
+            name: `${account.firstName} ${account.lastName}`,
+            first_name: account.firstName,
+            last_name: account.lastName,
+          },
+        })) as { user: { id: string } };
+
+        // 2) Create the admin profile linked to the auth user.
+        admin = adminRepo.create({
+          userId: result.user.id,
+          role: account.role,
+          status: account.status,
+        });
+
+        if (account.role === AdminRole.SUPER_ADMIN) {
+          admin.approved_at = new Date();
+        }
+
+        admin = await adminRepo.save(admin);
+        console.log(
+          `[CREATED] ${account.email} (${account.role} / ${account.status})`,
+        );
+      } catch (error) {
+        console.error(`[ERROR] Failed to seed ${account.email}:`, error);
+        continue;
+      }
+    }
+
+    seededAdmins.set(account.email, admin);
+  }
+
+  // 3) Link approved moderators to the SUPER_ADMIN.
+  const superAdmin = seededAdmins.get('superadmin@seed.local');
+
+  if (superAdmin) {
+    for (const account of SEED_ACCOUNTS.filter((a) => a.approved)) {
+      const moderator = seededAdmins.get(account.email);
+      if (moderator && !moderator.approvedBy) {
+        moderator.approvedBy = superAdmin;
+        moderator.approved_at = moderator.approved_at ?? new Date();
+        await adminRepo.save(moderator);
+        console.log(`[LINKED] ${account.email} to SUPER_ADMIN as approver`);
+      }
+    }
+  }
+
+  console.log('[SUCCESS] Admin seed finished successfully');
+}
+
+main()
+  .then(async () => {
+    if (dataSource.isInitialized) await dataSource.destroy();
+    process.exit(0);
+  })
+  .catch(async (error) => {
+    console.error('[FAILED] Admin seed failed:', error);
+    if (dataSource.isInitialized) await dataSource.destroy();
+    process.exit(1);
+  });


### PR DESCRIPTION
**Linked Issue**

Closes #36

**GitHub Project**

- Added this PR to the project board
- Issue is in the same project board

**Description 📑**

This PR adds an **Admin Seed script** that creates sample admin accounts covering the current admin workflow and statuses. It enables the team to quickly test the admin implementation without manual database inserts. The seed is idempotent (safe to run multiple times) and automatically creates the necessary Better Auth users before linking them to admin profiles.

**Type of Change**

✨ New feature (non-breaking change which adds functionality)

**Changes**

This pull request includes the following changes:

- **src/seeds/admin.seed.ts** — Created an idempotent seed script that:
  - Registers the `Admin` entity manually on the shared DataSource (since Better Auth tables are the only entities loaded by default)
  - Creates 5 seeded accounts via `auth.api.signUpEmail` (Better Auth) and then links them to the `admins` table:
    - 1 `SUPER_ADMIN` (ACTIVE, with `approved_at` set)
    - 4 `MODERATOR` accounts covering all statuses: `ACTIVE`, `PENDING`, `REJECTED`, `SUSPENDED`
  - Links the ACTIVE moderator to the SUPER_ADMIN as the approver (`approvedBy` + `approved_at`)
  - Checks for existing accounts by email before creating (prevents duplicates on re-runs)
  - Updates role/status if drifted, otherwise skips already-existing accounts

- **package.json** — Added `"seed:admin": "ts-node src/seeds/admin.seed.ts"` to scripts for easy execution.

- **src/README.md** — Documented the seed command, password, and a table of all seeded accounts with their roles and statuses.

**How to test 🚦**

1. Run the seed:
   ```bash
   npm run seed:admin
   ```
   You should see `[CREATED]` for all 5 accounts, then `[LINKED]` for the ACTIVE moderator.

2. Run it again to verify idempotency:
   ```bash
   npm run seed:admin
   ```
   All 5 accounts should be reported as `[SKIPPED]` — no duplicates created.

3. Verify the data directly from the database:
   ```bash
   docker exec -it pc_db psql -U pc_user -d parental_control_db -c 'SELECT user_id, role::text, status::text, approved_by IS NOT NULL AS is_approved, approved_at IS NOT NULL AS has_approval_date FROM admins;'
   ```
   The ACTIVE moderator should have `is_approved = t` (true) and `has_approval_date = t` (true), confirming it is linked to the SUPER_ADMIN.

**Acceptance Criteria met**

- ✅ Admin seed creates all required accounts (SUPER_ADMIN + 4 Moderators with all statuses)
- ✅ Seeded statuses match the current admin flow
- ✅ Approved moderator (ACTIVE) is linked to the SUPER_ADMIN when needed
- ✅ Running the seed multiple times does not create duplicates (idempotent)
- ✅ npm script added (`npm run seed:admin`)
- ✅ Seeded accounts documented in README with emails, roles, statuses, and password